### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out/
 node_modules/
+yarn.lock


### PR DESCRIPTION
Ignores yarn.lock in order to facilitate the usage of yarn.